### PR TITLE
Remove vim-polyglot

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -108,7 +108,6 @@ Plug "tpope/vim-fugitive"
 Plug "lewis6991/gitsigns.nvim"
 Plug "rhysd/vim-lsp-ale"
 Plug "sbdchd/neoformat"
-Plug "sheerun/vim-polyglot"
 Plug "numToStr/Comment.nvim"
 Plug "windwp/nvim-autopairs"
 


### PR DESCRIPTION
Replaced by built-in Neovim feature. Also it's known for causing problems.